### PR TITLE
Fixed C and C# Links Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
  - [JavaScript](#javascript)
  - [Java](#java)
- - [C#](#c-1)
+ - [C#](#c)
  - [CSS](#css)
  - [HTML](#html)
- - [C](undefined)
+ - [C](#c-1)
  - [C++](#c-2)
  - [ActionScript](#actionscript)
  - [Clojure](#clojure)


### PR DESCRIPTION
Opened this PR to fix below issue :

Issue --> C and C# links in Contents section are not working

![links issue](https://user-images.githubusercontent.com/25107841/47333290-f9916680-d69f-11e8-80fe-360eb3d83d82.gif)
